### PR TITLE
fixed bug for selection using keyboard input (shift+arrow)

### DIFF
--- a/codeview/src/main/java/com/amrdeveloper/codeview/CodeView.java
+++ b/codeview/src/main/java/com/amrdeveloper/codeview/CodeView.java
@@ -711,8 +711,6 @@ public class CodeView extends AppCompatMultiAutoCompleteTextView implements Find
         @Override
         public boolean onKey(View v, int keyCode, KeyEvent event) {
             if (!enableAutoIndentation) return false;
-            if (event.getAction() != KeyEvent.ACTION_DOWN)
-                return true;
             switch (keyCode) {
                 case KeyEvent.KEYCODE_SPACE:
                     currentIndentation++;


### PR DESCRIPTION
Text Selection ( Shift + Arrow key ) is not working correctly, so I found bug & fix

repro steps:
1. press Shift 
2. press Arrow key 
3. select the code. 
4. release shift key
5. press arrow key

Text unselection  doesn't work.